### PR TITLE
Write fields textformatter

### DIFF
--- a/formatters.go
+++ b/formatters.go
@@ -90,13 +90,6 @@ func (t TextFormatter) Format(w io.Writer, logLevel LogLevel, wl WLogger, msg st
 		writeString(w, "]")
 	}
 
-	for key, value := range wl.GetFields() {
-		writeString(w, key)
-		writeString(w, "=")
-		writeString(w, fmt.Sprintf("%v", value))
-		writeString(w, ", ")
-	}
-
 	if len(msg) == 0 || msg[len(msg)-1] != '\n' {
 		writeString(w, "\n")
 	}

--- a/formatters.go
+++ b/formatters.go
@@ -84,11 +84,33 @@ func (t TextFormatter) Format(w io.Writer, logLevel LogLevel, wl WLogger, msg st
 	// Append log message to buffer
 	writeString(w, msg)
 
+	if len(wl.GetFields()) > 0 {
+		writeString(w, " [ ")
+		writeFields(w, wl.GetFields())
+		writeString(w, "]")
+	}
+
+	for key, value := range wl.GetFields() {
+		writeString(w, key)
+		writeString(w, "=")
+		writeString(w, fmt.Sprintf("%v", value))
+		writeString(w, ", ")
+	}
+
 	if len(msg) == 0 || msg[len(msg)-1] != '\n' {
 		writeString(w, "\n")
 	}
 
 	return nil
+}
+
+func writeFields(w io.Writer, fields Fields) {
+	for key, value := range fields {
+		writeString(w, key)
+		writeString(w, "=")
+		writeString(w, fmt.Sprintf("%v", value))
+		writeString(w, ", ")
+	}
 }
 
 func getTimestamp(now time.Time) string {

--- a/wlog.go
+++ b/wlog.go
@@ -142,7 +142,7 @@ func (l *Logger) WithScope(fields Fields) *ScopedLogger {
 	for k, v := range l.fields {
 		scopeFields[k] = v
 	}
-	return &ScopedLogger{scopeFields, l, JSONFormatter{}}
+	return &ScopedLogger{scopeFields, l, l.formatter}
 }
 
 // SetGlobalFields set fields in a global wlog instance. These fields will be appended to any
@@ -156,7 +156,6 @@ func (l *Logger) SetGlobalFields(f Fields) {
 	l.lock.Lock()
 	defer l.lock.Unlock()
 	l.fields = fields
-	l.formatter = JSONFormatter{}
 }
 
 // Debugf formats and logs a debug message


### PR DESCRIPTION
To improve readability of the log while in development, it would be good to have the logs in text format.

Changes:
- Skip setting the `JSONFormatter` by default when calling `SetGlobalFields` and `WithScope` methods, and use the `Formatter` that is set in the global logger instance instead.

- Introduced a private function called `writeFields` which is called when using the `TextFormatter` and it will print in plain text format the keys and values of the `Fields` map.