### PR TITLE
Support for compact prop in JSONFormatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ import "github.com/vargspjut/wlog"
 func main() {
 
     wlog.SetLogLevel(wlog.Nfo)
+    wlog.SetFormatter(wlog.JSONFormatter{})
     wlog.SetGlobalFields(wlog.Fields{"userId": "dd18f2b6-35df-11ea-bb24-c0b88337ca26"})
 
     logger := wlog.WithScope(wlog.Fields{"field1": "field1_value"})
@@ -99,6 +100,25 @@ Running this code you should see the output below:
 {"field1":"field1_value","level":"Info","msg":"This is another log entry","timestamp":"2020-01-23 09:57:54:157273","userId":"dd18f2b6-35df-11ea-bb24-c0b88337ca26"}
 ``` 
 Note that we call the method `Info` two times with different messages, however, the field `userId` added to the global scope sticks with the logger and it is part of the log entry at all times. This behaviour was inspired by the great library [logrus](https://github.com/sirupsen/logrus)
+
+The `JsonFormatter` has support for compact property names, this can be achieved by setting its
+property `Compact` to `true`, like so:
+
+```golang
+wlog.SetLogLevel(wlog.Nfo)
+wlog.SetFormatter(wlog.JSONFormatter{Compact: true})
+wlog.SetGlobalFields(wlog.Fields{"userId": "dd18f2b6-35df-11ea-bb24-c0b88337ca26"})
+
+wlog.Info("This is a log entry")
+```
+Output:
+```json
+{"@l":"Info","@m":"This is a log entry","@t":"2020-02-05 12:19:30:163927","userId":"dd18f2b6-35df-11ea-bb24-c0b88337ca26"}
+```
+Note that, the default fields `level`, `timestamp` and `message` are renamed to its first letter prefixed
+with a `@` symbol. The `Compact` property in the `JsonFormatter` is optional and it is set to `false`
+by default.
+
 ## Test
 ```
 go test

--- a/formatters.go
+++ b/formatters.go
@@ -33,7 +33,7 @@ func (j JSONFormatter) Format(w io.Writer, logLevel LogLevel, wl WLogger, msg st
 
 	fields[j.getKey("msg")] = msg
 	fields[j.getKey("timestamp")] = getTimestamp(timestamp)
-	fields[j.getKey("loglevel")] = logLevel.String()
+	fields[j.getKey("level")] = logLevel.String()
 
 	encoder := json.NewEncoder(w)
 

--- a/formatters.go
+++ b/formatters.go
@@ -16,15 +16,24 @@ type Formatter interface {
 }
 
 // JSONFormatter used to output logs in JSON format
-type JSONFormatter struct{}
+type JSONFormatter struct {
+	Compact bool
+}
+
+func (j JSONFormatter) getKey(key string) string {
+	if j.Compact {
+		return "@" + key[:1]
+	}
+	return key
+}
 
 // Implements Formatter.Format
 func (j JSONFormatter) Format(w io.Writer, logLevel LogLevel, wl WLogger, msg string, timestamp time.Time) error {
 	fields := wl.GetFields()
 
-	fields["msg"] = msg
-	fields["timestamp"] = getTimestamp(timestamp)
-	fields["level"] = logLevel.String()
+	fields[j.getKey("msg")] = msg
+	fields[j.getKey("timestamp")] = getTimestamp(timestamp)
+	fields[j.getKey("loglevel")] = logLevel.String()
 
 	encoder := json.NewEncoder(w)
 

--- a/formatters.go
+++ b/formatters.go
@@ -31,9 +31,11 @@ func (j JSONFormatter) getKey(key string) string {
 func (j JSONFormatter) Format(w io.Writer, logLevel LogLevel, wl WLogger, msg string, timestamp time.Time) error {
 	fields := wl.GetFields()
 
+	wl.lock()
 	fields[j.getKey("msg")] = msg
 	fields[j.getKey("timestamp")] = getTimestamp(timestamp)
 	fields[j.getKey("level")] = logLevel.String()
+	wl.unlock()
 
 	encoder := json.NewEncoder(w)
 

--- a/formatters_test.go
+++ b/formatters_test.go
@@ -13,8 +13,8 @@ func Test_JSONFormatter(t *testing.T) {
 		formatter Formatter
 	}
 	tests := []struct {
-		name string
-		args args
+		name           string
+		args           args
 		resultTemplate string
 	}{
 		{

--- a/formatters_test.go
+++ b/formatters_test.go
@@ -9,22 +9,45 @@ import (
 )
 
 func Test_JSONFormatter(t *testing.T) {
-
-	now := time.Now()
-	expected := fmt.Sprintf(`{"field1":"test value","level":"Info","msg":"test value","timestamp":"%s"}`, getTimestamp(now))
-
-	SetLogLevel(Nfo)
-	SetGlobalFields(Fields{"field1": "test value"})
-
-	buf := &bytes.Buffer{}
-
-	if err := logger.formatter.Format(buf, Nfo, logger, "test value", now); err != nil {
-		t.Fatalf("failed to format the log entry, err: %s", err)
+	type args struct {
+		formatter Formatter
 	}
+	tests := []struct {
+		name string
+		args args
+		resultTemplate string
+	}{
+		{
+			"Parse to JSON",
+			args{JSONFormatter{}},
+			`{"field1":"test value","level":"Info","msg":"test value","timestamp":"%s"}`},
+		{
+			"Parse to JSON with compact fields",
+			args{JSONFormatter{Compact: true}},
+			`{"@l":"Info","@m":"test value","@t":"%s","field1":"test value"}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Now()
+			want := fmt.Sprintf(tt.resultTemplate, getTimestamp(now))
 
-	result := strings.TrimSuffix(buf.String(), "\n")
+			logger := DefaultLogger()
+			logger.SetLogLevel(Nfo)
+			logger.SetFormatter(tt.args.formatter)
+			logger.SetGlobalFields(Fields{"field1": "test value"})
 
-	if result != expected {
-		t.Fatalf("Expected: %s, got %s", expected, result)
+			buf := &bytes.Buffer{}
+
+			if err := logger.formatter.Format(buf, Nfo, logger, "test value", now); err != nil {
+				t.Fatalf("failed to format the log entry, err: %s", err)
+			}
+
+			got := strings.TrimSuffix(buf.String(), "\n")
+
+			if got != want {
+				t.Errorf("formatter.Format() = %v, want %v", got, want)
+			}
+		})
 	}
 }

--- a/formatters_test.go
+++ b/formatters_test.go
@@ -35,6 +35,7 @@ func Test_JSONFormatter(t *testing.T) {
 			logger := DefaultLogger()
 			logger.SetLogLevel(Nfo)
 			logger.SetFormatter(tt.args.formatter)
+			logger.SetStdOut(false)
 			logger.SetGlobalFields(Fields{"field1": "test value"})
 
 			buf := &bytes.Buffer{}

--- a/scopedLogger.go
+++ b/scopedLogger.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 )
 
@@ -15,6 +16,15 @@ type ScopedLogger struct {
 	fields    Fields
 	logger    *Logger
 	formatter Formatter
+	mux       sync.Mutex
+}
+
+func (s *ScopedLogger) lock() {
+	s.mux.Lock()
+}
+
+func (s *ScopedLogger) unlock() {
+	s.mux.Unlock()
 }
 
 // GetFields implements WLogger.GetFields

--- a/scopedLogger.go
+++ b/scopedLogger.go
@@ -16,15 +16,15 @@ type ScopedLogger struct {
 	fields    Fields
 	logger    *Logger
 	formatter Formatter
-	mux       sync.Mutex
+	mutex     sync.Mutex
 }
 
 func (s *ScopedLogger) lock() {
-	s.mux.Lock()
+	s.mutex.Lock()
 }
 
 func (s *ScopedLogger) unlock() {
-	s.mux.Unlock()
+	s.mutex.Unlock()
 }
 
 // GetFields implements WLogger.GetFields

--- a/wlog.go
+++ b/wlog.go
@@ -96,7 +96,7 @@ type Logger struct {
 	writer    io.Writer
 	logLevel  LogLevel
 	stdOut    bool
-	mux       sync.Mutex
+	mutex     sync.Mutex
 	hooks     map[LogLevel][]HookFunc
 	fields    Fields
 	formatter Formatter
@@ -107,11 +107,11 @@ var bufferPool = sync.Pool{New: func() interface{} {
 }}
 
 func (l *Logger) lock() {
-	l.mux.Lock()
+	l.mutex.Lock()
 }
 
 func (l *Logger) unlock() {
-	l.mux.Unlock()
+	l.mutex.Unlock()
 }
 
 // Configure configures the logger
@@ -152,7 +152,7 @@ func (l *Logger) WithScope(fields Fields) *ScopedLogger {
 	for k, v := range l.fields {
 		scopeFields[k] = v
 	}
-	return &ScopedLogger{scopeFields, l, l.formatter, sync.Mutex{}}
+	return &ScopedLogger{fields: scopeFields, logger: l, formatter: l.formatter}
 }
 
 // SetGlobalFields set fields in a global wlog instance. These fields will be appended to any


### PR DESCRIPTION
Adds support for compact properties in the `JSONFormatter`, this will replace the default properties "level", "timestamp" and "message" by property named using its first letter prefixed by `@` symbol. For example: timestamp will be displayed as @t when `Compact` is set to true.